### PR TITLE
Fill type with class name for empty `log_entity_name`

### DIFF
--- a/lib/loggun/helpers.rb
+++ b/lib/loggun/helpers.rb
@@ -139,7 +139,9 @@ module Loggun
       type_as_arr = type.split('.')
 
       if type_as_arr.size == 1
-        log_entity_name = klass.respond_to?(:log_entity_name) ? klass.log_entity_name : underscore(klass.name.dup)
+        log_entity_name = klass.log_entity_name if klass.respond_to?(:log_entity_name)
+
+        log_entity_name ||= underscore(klass.name.dup)
         type_as_arr << log_entity_name
       end
 


### PR DESCRIPTION
Исправляет логирование `type` при пустом значении `log_entity_name`.