### PR TITLE
Middleware Changes for Sidekiq 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,21 @@
 # Changelog
 
+## 0.7.0 - 2023-09-19
+* fixes
+  * Middleware Changes for Sidekiq 7.0
+
 ## 0.6.0 - 2020-09-22
 * features
   * Sidekiq client middlware for logging enqueued jobs
 
 ## 0.5.1 - 2020-09-22
 * fix
-  * `message` string only in `log_format == :json` 
+  * `message` string only in `log_format == :json`
 
 ## 0.5.0 - 2020-09-22
 * features
   * `config.log_format` - for control full log rows format
-  * `config.exclude_keys`, `config.include_keys` - for include or exclude keys from `:json` log_format 
+  * `config.exclude_keys`, `config.include_keys` - for include or exclude keys from `:json` log_format
 
 ## 0.4.1 - 2020-07-28
 * fixes

--- a/lib/loggun/modifiers/sidekiq.rb
+++ b/lib/loggun/modifiers/sidekiq.rb
@@ -8,8 +8,16 @@ module Loggun
       def apply
         return unless defined?(::Sidekiq) && ::Sidekiq::VERSION >= MIN_SIDEKIQ_V
 
-        ::Sidekiq.client_middleware do |chain|
-          chain.add ClientMiddleware
+        if ::Sidekiq::VERSION >= '7.0.0'
+          ::Sidekiq.configure_client do |config|
+            config.client_middleware do |chain|
+              chain.add ClientMiddleware
+            end
+          end
+        else
+          ::Sidekiq.client_middleware do |chain|
+            chain.add ClientMiddleware
+          end
         end
 
         ::Sidekiq.configure_server do |config|

--- a/lib/loggun/version.rb
+++ b/lib/loggun/version.rb
@@ -1,3 +1,3 @@
 module Loggun
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.7.0'.freeze
 end


### PR DESCRIPTION
При переходе на sidekiq 7 запуск приложения валится с 
```
undefined method `client_middleware' for Sidekiq:Module (NoMethodError)

          ::Sidekiq.client_middleware do |chain|
                   ^^^^^^^^^^^^^^^^^^
```
Это связанно с [внутренним рефакторингом sidekiq](https://github.com/sidekiq/sidekiq/blob/v6.5.9/docs/middleware.md#existing-client-api).